### PR TITLE
[fix]global-nav__menuのContactの修正。

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -37,7 +37,7 @@
                 <li><a href="#about-me">About</a></li>
                 <li><a href="">Blog</a></li>
                 <li><a href="#about-works">Works</a></li>
-                <li><a href="https://twitter.com/23_tas9" class="twitter-logo" target="_blank" rel="noopener noreferrer">Contact</a></li>
+                <li><a href="https://twitter.com/23_tas9" target="_blank" rel="noopener noreferrer">Contact</a></li>
             </ul>
         </nav>
     </header>


### PR DESCRIPTION
Twitterのロゴが表示されていたので、Contactのaタグからclass="twitter-logo"を除去